### PR TITLE
gentoo-gh-prtester.sh: ensure candidate file names end in .ebuild

### DIFF
--- a/container/bin/gentoo-gh-prtester.sh
+++ b/container/bin/gentoo-gh-prtester.sh
@@ -18,7 +18,7 @@ if [[ -z "$(git rev-list origin/HEAD..HEAD)" ]]; then
 fi
 
 candidates="$(git show --name-only --diff-filter=AMR --format=tformat: \
-	origin/HEAD..HEAD | sort -u | grep ebuild)"
+	origin/HEAD..HEAD | sort -u | grep '\.ebuild$')"
 pkgstobetested=()
 for ebuild in ${candidates}; do
 	[[ -f "${ebuild}" ]] && pkgstobetested+=("${ebuild}")


### PR DESCRIPTION
Previously, any file name that contained the string 'ebuild' was passed forward to pkg-testing-tools. I recently tested a commit that changed the patch file "anki-24.06.3-pr**ebuild**-node_modules.patch", breaking the logic.

Fixes: a1ef3b07ae90d49bdafef8cf31a8e0bd4fced297